### PR TITLE
add a /healthcheck endpoint

### DIFF
--- a/back-end/routes/api-router.js
+++ b/back-end/routes/api-router.js
@@ -5,6 +5,9 @@ const DAppsRoute = require('./dapps-routes');
 class APIRouter {
     static route(app) {
         app.use('/metadata', DAppsRoute.build(express));
+
+        /* for ElasticBeanstalk Load Balancer healthcheck */
+        app.use('/healthcheck', async (req, res) => res.send('OK'))
     }
 }
 


### PR DESCRIPTION
ElasticBeanstalk applications using an ELB need a `/healtcheck` endpoint.

https://docs.aws.amazon.com/elasticloadbalancing/latest/network/target-group-health-checks.html