### PR TITLE
add a redirect to https for production

### DIFF
--- a/back-end/routes/api-router.js
+++ b/back-end/routes/api-router.js
@@ -8,6 +8,15 @@ class APIRouter {
 
         /* for ElasticBeanstalk Load Balancer healthcheck */
         app.use('/healthcheck', async (req, res) => res.send('OK'))
+
+        /* redirect if not on https on prod */
+        app.use(async (req, res, next) => {
+            if (req.get('x-forwarded-proto') == 'http') {
+              res.redirect('https://' + req.headers.host + req.url);
+            } else {
+              next()
+            }
+        });
     }
 }
 


### PR DESCRIPTION
Requests in production should always be redirected to HTTPS.

Please test it.