### PR TITLE
add a catch-all to express for paths not matching specific files

### DIFF
--- a/back-end/server.js
+++ b/back-end/server.js
@@ -1,3 +1,4 @@
+const path = require('path')
 const config = require('./config')
 
 function setupSystem() {
@@ -23,6 +24,12 @@ async function setupAPI() {
     setupPostRoutedAppMiddlewares(app);
 
     app.use(express.static('frontend'));
+
+    /* Handles any requests that don't match the ones above */
+    app.get('*', (req,res) =>{
+        res.sendFile(path.join(__dirname, 'frontend/index.html'));
+    });
+
     app.listen(config.PORT);
     console.log(`Server started on port: ${config.PORT}`);
 


### PR DESCRIPTION
This fixes #9 issue with server not handling paths that are not in the `frontentd` folder.