### PR TITLE
Local setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ dist
 full-build
 flattenedContracts
 src/embarkArtifacts
+shared.development.chains.json
 
 # See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
 

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,13 @@
 .PHONY: help clean purge compile-contracts patch-ipfs mk-build-dir copy-misc copy-backend compile-js copy-frontend archive
 
-export NODE_ENV ?= development
-export LOCALHOST ?= 1
+export NODE_ENV ?= localhost
 export WALLET_PASSWORD ?= dev_password
 export WALLET_MNEMONIC ?= erupt point century seek certain escape solution flee elegant hard please pen
 
 ifeq ($(NODE_ENV),production)
 export EMBARK_TARGET ?= livenet
 else
-  ifeq (LOCALHOST, localhost) 
+  ifeq ($(NODE_ENV), localhost) 
   export EMBARK_TARGET ?= development
   else
   export EMBARK_TARGET ?= testnet
@@ -33,7 +32,7 @@ help: ##@miscellaneous Show this help.
 
 all: ##@build Build the final app.zip from scratch
 all: node_modules clean compile-contracts patch-ipfs mk-build-dir copy-misc copy-backend compile-js copy-frontend archive install-build
-ifneq ($(LOCALHOST),1)
+ifneq ($(NODE_ENV),localhost)
 	@echo "SUCCESS! Use the app.zip file."
 else
 	@echo "SUCCESS! Execute 'yarn server-start' and browse http://localhost:4000"
@@ -47,9 +46,9 @@ ifeq ($(NODE_ENV),production)
 	[[ -z "${WALLET_MNEMONIC}" ]] && { echo "Not defined: WALLET_MNEMONIC"; exit 1 }
 	[[ -z "${WALLET_PASSWORD}" ]] && { echo "Not defined: WALLET_PASSWORD"; exit 1 }
 else
-ifneq ($(NODE_ENV),development)
+ifneq ($(NODE_ENV),$(filter $(NODE_ENV),development localhost))
 	@echo "Unknown NODE_ENV value: ${NODE_ENV}"
-	@echo "Use 'production' or 'development'."
+	@echo "Use 'production' or 'development' or 'localhost'."
 	exit 1
 endif
 endif
@@ -80,18 +79,18 @@ copy-misc: ##@copy Copy over the miscalenious config config files
 
 
 archive: ##@archive Create the app.zip archive for use with ElasticBeanstalk when running on testnet or mainnet
-ifneq ($(LOCALHOST),1)
+ifneq ($(NODE_ENV),localhost)
 archive: clean-archive
 	cd full-build && zip -r ../app.zip ./
 endif
 
 install-build:
-ifeq ($(LOCALHOST),1)
+ifeq ($(NODE_ENV),localhost)
 	cd full-build && yarn
 endif
 
 clean-archive: ##@clean Remove app.zip
-ifneq ($(LOCALHOST),1)
+ifneq ($(NODE_ENV),localhost)
 	rm -f app.zip
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ all: node_modules clean compile-contracts patch-ipfs mk-build-dir copy-misc copy
 ifneq ($(LOCALHOST),1)
 	@echo "SUCCESS! Use the app.zip file."
 else
-	@echo "SUCCESS! Execute 'yarn start-server' and browse http://localhost:4000"
+	@echo "SUCCESS! Execute 'yarn server-start' and browse http://localhost:4000"
 endif
 
 node_modules: ##@install Install the Node.js dependencies using Yarn

--- a/Makefile
+++ b/Makefile
@@ -7,11 +7,11 @@ export WALLET_MNEMONIC ?= erupt point century seek certain escape solution flee 
 ifeq ($(NODE_ENV),production)
 export EMBARK_TARGET ?= livenet
 else
-  ifeq ($(NODE_ENV), localhost) 
-  export EMBARK_TARGET ?= development
-  else
-  export EMBARK_TARGET ?= testnet
-  endif
+ifeq ($(NODE_ENV), localhost) 
+export EMBARK_TARGET ?= development
+else
+export EMBARK_TARGET ?= testnet
+endif
 endif
 
 HELP_FUN = \

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ On Linux, setting up `mongodb` is as easy as `sudo apt install -y mongodb`, whic
 
 1. `export DB_CONNECTION=mongodb://localhost:27017/mydb`. Make sure you have `DB_CONNECTION` set as an ENV variable so the app knows where to find your local DB.
 2. `yarn run build:localhost`. This will:
-    1. Compile all you contracts using Embark, connecting to Ropsten and IPFS through an Infura gateway.
+    1. Compile all your contracts using Embark, connecting to Ropsten and IPFS through an Infura gateway.
     2. Deploy a new instance of Discover onto the Ropsten test network for you to work from. It will only be deployed once, after that the address of your contract is stored in, and fetched from, `shared.development.chains.json`.
     3. Build the frontend, create a directory called `full-build`, move each directory from the `back-end` into it, and include the `frontend` as a directory of its own. It will make sure `node_modules` are installed, then you can serve everything in `full-build` by running:
 3. `yarn server-start`. Navigate to `http://localhost:4000` to get developing cool new things for the future of curated information. 
@@ -67,12 +67,12 @@ On Linux, setting up `mongodb` is as easy as `sudo apt install -y mongodb`, whic
  
 #### Running unit tests
 
-Use `embark test`
+Use `./node_modules/.bin/embark test`
 
-Will compile your contracts, with hot-reloading, and let you test them locally to your heart's content. 
+To test a specific smart contract you can use `./node_modules/.bin/embark test test/Discover_spec.js`. 
 
 #### Running slither
 
-`slither . --exclude naming-convention --filter-paths token `
+`slither . --exclude naming-convention --filter-paths token`
 
-Make sure you get TrailofBits' [latest static analysis tool](https://securityonline.info/slither/), and do your own static analysis on the relevant contracts that will be deployed for Discover.
+Make sure you get TrailofBits' [latest static analysis tool](https://securityonline.info/slither/), and do your own static analysis on the relevant contracts that you are working on.

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Discover: { address: '0xC8d48B421eAFdD75d5144E8f06882Cb5F0746Bd2' },
 
 The goal of our local build process is to abstract away the complexity with smart contracts so that you can focus on adding useful new functionality through React-based bounties that are easy to get started on.
 
-#### Prerequisites
+#### 3 Prerequisites
 
 1. [Node v10](https://github.com/nvm-sh/nvm) or higher.
 2. [Yarn](https://yarnpkg.com/).
@@ -46,7 +46,7 @@ The goal of our local build process is to abstract away the complexity with smar
 
 On Linux, setting up `mongodb` is as easy as `sudo apt install -y mongodb`, which will also start it automatically. You can stop/restart your local DB any time with `sudo systemctl stop mongodb`, or get its status with `sudo systemctl status mongodb`.
 
-#### Begin
+#### 4 Quick Steps
 
 1. `export DB_CONNECTION=mongodb://localhost:27017/mydb`. Make sure you have `DB_CONNECTION` set as an ENV variable so the app knows where to find your local DB.
 2. `yarn run build:localhost`. This will:
@@ -54,6 +54,8 @@ On Linux, setting up `mongodb` is as easy as `sudo apt install -y mongodb`, whic
     2. Deploy a new instance of Discover onto the Ropsten test network for you to work from. It will only be deployed once, after that the address of your contract is stored in, and fetched from, `shared.development.chains.json`.
     3. Build the frontend, create a directory called `full-build`, move each directory from the `back-end` into it, and include the `frontend` as a directory of its own. It will make sure `node_modules` are installed, then you can serve everything in `full-build` by running:
 3. `yarn server-start`. Navigate to `http://localhost:4000` to get developing cool new things for the future of curated information. 
+
+**Note:** You'll need to visit [simpledapp.eth using Status](https://status.im/get/) -> Assets Tab -> Request `STT`. This is the Status Test Token on Ropsten that needs to be used with your instance of Discover in order to submit/upvote/downvote in your local app. Using a proper test network even for local development allows us to better understand what the user experience is actually like in production more easily.
 
 #### Work to be done
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Discover new and useful DApps that are mobile-friendly and easy to use. Viewing curated information does not require any special tools, though effecting the way information is ranked will require a web3 wallet, whether that is Status, MetaMask, Trust, Brave or whichever one you prefer.
 
+You can learn more about bonded curves and how Discover works [here](https://our.status.im/discover-a-brave-new-curve/).
+
 ## Available Scripts
 
 This project is based on Embark v4.0.1, with a few things customised for React. 
@@ -29,26 +31,37 @@ Mainnet:
 
 ```
 MiniMeToken: { address: '0x744d70fdbe2ba4cf95131626614a1763df805b9e' },
-Discover: { address: '0x5bCF2767F86f14eDd82053bfBfd5069F68C2C5F8' },
+Discover: { address: '0xC8d48B421eAFdD75d5144E8f06882Cb5F0746Bd2' },
 ```
 
 ## Running It Locally
 
-Because we need a review stage for DApps, running this application locally can be challenging. We will fix this in due course.
+The goal of our local build process is to abstract away the complexity with smart contracts so that you can focus on adding useful new functionality through React-based bounties that are easy to get started on.
 
-#### Step 1.1 Understand The Contracts
+#### Prerequisites
 
-Check the `config/contracts.js` file in order to check you're working with the correct contract instance and network.  
+1. [Node v10](https://github.com/nvm-sh/nvm) or higher.
+2. [Yarn](https://yarnpkg.com/).
+3. [mongodb](https://www.mongodb.com/).
 
-#### Step 1.2 Use Embark Locally
+On Linux, setting up `mongodb` is as easy as `sudo apt install -y mongodb`, which will also start it automatically. You can stop/restart your local DB any time with `sudo systemctl stop mongodb`, or get its status with `sudo systemctl status mongodb`.
 
-1. Run `./node_modules/.bin/embark build` to build locally. 
-2. Go to L 125 of `src/embarkArtifacts/embarkjs.js` and change `_ipfsConnection.id()` to `_ipfsConnection.version()` due to IPFS deprecating their id() endpoint.
+#### Begin
 
-#### Step 1.3 Build the Application
+1. `export DB_CONNECTION=mongodb://localhost:27017/mydb`. Make sure you have `DB_CONNECTION` set as an ENV variable so the app knows where to find your local DB.
+2. `yarn run build:localhost`. This will:
+    1. Compile all you contracts using Embark, connecting to Ropsten and IPFS through an Infura gateway.
+    2. Deploy a new instance of Discover onto the Ropsten test network for you to work from. It will only be deployed once, after that the address of your contract is stored in, and fetched from, `shared.development.chains.json`.
+    3. Build the frontend, create a directory called `full-build`, move each directory from the `back-end` into it, and include the `frontend` as a directory of its own. It will make sure `node_modules` are installed, then you can serve everything in `full-build` by running:
+3. `yarn server-start`. Navigate to `http://localhost:4000` to get developing cool new things for the future of curated information. 
 
-1. Run `yarn run start`
-2. You may find you still having issues to get it to work as it cannot fetch data from `http://localhost:3000/metadata/all`. We will fix this in due course.
+#### Work to be done
+
+1. Integrate Kyber functionality so that people can use (at least) SNT, ETH and DAI to participate in the store (it just gets exchanged in the background into SNT before being submitted to the contract).
+2. Create a `downvote pool` for each DApp so that anyone can downvote by any amount, not just 1%. When the pool hits 1%, the downvote is sent to the contract. This will be important if people ever stake large amounts, 1% of which may be too expensive for individual users. It will potentially amplify "the community's" ability to respond to bad actors.
+3. Integrate [embeddable whisper chats](https://github.com/status-im/status-chat-widget) into the site, so that it is easy to plug into the community chat directly "behind" each DApp (it's just the name of the DApp as a whisper topic, i.e. #cryptokitties).
+4. Research a way to fetch information about popular DApps on Ethereum through non-economic metrics. Perhaps this means just plugging into an API from OpenSea/StateOfTheDApps for now and leveraging their work. Perhaps it means figuring out how to [gossip information about use of DApps via whisper](https://discuss.status.im/t/friend-to-friend-content-discovery-community-feeds/1212)?
+
  
 #### Running unit tests
 

--- a/back-end/server.js
+++ b/back-end/server.js
@@ -23,7 +23,7 @@ async function setupAPI() {
 
     setupPostRoutedAppMiddlewares(app);
 
-    app.use(express.static('frontend'));
+    app.use(express.static(path.join(__dirname, '/frontend')));
 
     /* Handles any requests that don't match the ones above */
     app.get('*', (req,res) =>{

--- a/config/blockchain.js
+++ b/config/blockchain.js
@@ -48,18 +48,14 @@ module.exports = {
   // default environment, merges with the settings in default
   // assumed to be the intended environment by `embark run` and `embark blockchain`
   development: {
-    ethereumClientName: 'geth', // Can be geth or parity (default:geth)
-    // ethereumClientBin: "geth",  // path to the client binary. Useful if it is not in the global PATH
-    networkType: 'custom', // Can be: testnet, rinkeby, livenet or custom, in which case, it will use the specified networkId
-    networkId: 1337, // Network id used when networkType is custom
-    isDev: true, // Uses and ephemeral proof-of-authority network with a pre-funded developer account, mining enabled
-    datadir: '.embark/development/datadir', // Data directory for the databases and keystore (Geth 1.8.15 and Parity 2.0.4 can use the same base folder, till now they does not conflict with each other)
-    mineWhenNeeded: true, // Uses our custom script (if isDev is false) to mine only when needed
-    nodiscover: true, // Disables the peer discovery mechanism (manual peer addition)
-    maxpeers: 0, // Maximum number of network peers (network disabled if set to 0) (default: 25)
-    proxy: true, // Proxy is used to present meaningful information about transactions
-    targetGasLimit: 9000000, // Target gas limit sets the artificial target gas floor for the blocks to mine
-    simulatorBlocktime: 0, // Specify blockTime in seconds for automatic mining. Default is 0 and no auto-mining.
+    networkType: 'testnet',
+    syncMode: 'light',
+    accounts: [
+      {
+        nodeAccounts: true,
+        password: process.env.WALLET_PASSWORD,
+      },
+    ],
   },
 
   // merges with the settings in default

--- a/config/contracts.js
+++ b/config/contracts.js
@@ -80,20 +80,29 @@ module.exports = {
   // default environment, merges with the settings in default
   // assumed to be the intended environment by `embark run`
   development: {
+    deployment: {
+      accounts: [
+        {
+          mnemonic: process.env.WALLET_MNEMONIC,
+        },
+      ],
+      host: `ropsten.infura.io/v3/8675214b97b44e96b70d05326c61fd6a`,
+      port: false,
+      type: 'rpc',
+      protocol: 'https',
+    },
+    dappConnection: [
+      '$WEB3',
+      'https://ropsten.infura.io/v3/8675214b97b44e96b70d05326c61fd6a',
+    ],
+    dappAutoEnable: false,
+    gasPrice: "10000000000",
     contracts: {
-      MiniMeTokenFactory: {},
       MiniMeToken: {
-        args: [
-          '$MiniMeTokenFactory',
-          '0x0000000000000000000000000000000000000000',
-          0,
-          'SNTMiniMeToken',
-          18,
-          'SNT',
-          true,
-        ],
+        address: '0xc55cf4b03948d7ebc8b9e8bad92643703811d162',
       },
     },
+    tracking: 'shared.development.chains.json',
   },
 
   // merges with the settings in default

--- a/config/storage.js
+++ b/config/storage.js
@@ -29,17 +29,23 @@ module.exports = {
   // assumed to be the intended environment by `embark run`
   development: {
     enabled: true,
+    ipfs_bin: 'ipfs',
+    provider: 'ipfs',
+    available_providers: ['ipfs'],
     upload: {
-      provider: 'ipfs',
       host: 'localhost',
       port: 5001,
-      getUrl: 'http://localhost:8080/ipfs/',
     },
+    dappConnection: [
+      {
+        provider: 'ipfs',
+        protocol: 'https',
+        host: 'ipfs.infura.io',
+        port: 5001,
+        getUrl: 'https://ipfs.infura.io/ipfs/',
+      },
+    ],
   },
-
-  // merges with the settings in default
-  // used with "embark run privatenet"
-  privatenet: {},
 
   // merges with the settings in default
   // used with "embark run testnet"
@@ -84,9 +90,4 @@ module.exports = {
       },
     ],
   },
-
-  // you can name an environment with specific settings and then specify with
-  // "embark run custom_name"
-  // custom_name: {
-  // }
 }

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "web3-utils": "^1.0.0-beta.35"
   },
   "scripts": {
+    "build:localhost": "NODE_ENV=localhost make all",
     "build:dev": "NODE_ENV=development make all",
     "build:prod": "NODE_ENV=production make all",
     "start": "./node_modules/.bin/react-scripts start",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "build:dev": "NODE_ENV=development make all",
     "build:prod": "NODE_ENV=production make all",
     "start": "./node_modules/.bin/react-scripts start",
+    "server-start": "node ./full-build/server.js",
     "build": "./node_modules/.bin/react-scripts build",
     "test": "./node_modules/.bin/react-scripts test",
     "eject": "./node_modules/.bin/react-scripts eject",


### PR DESCRIPTION
This PR is to fix https://github.com/dap-ps/discover/issues/33

1. Set the DB_CONNECTION variable with a valid mongodb connection string. This step was not documented on the README.md.

```
export DB_CONNECTION=mongodb://localhost:27017/mydb
```

Afterwards, the developer can run `yarn build:localhost`. This will set the `NODE_ENV` variable to `localhost`, and deploy an instance of the Discover contract in ropsten. 

Executing `yarn build:dev` and `yarn build:prod` will reuse the Discover contract from testnet or mainnet (depending of `NODE_ENV`).

2. `yarn server-start` was added to the script list and will initiate the backend service and express webserver which can be used to browse the dapp at http://localhost:4000

3. Fixed an issue with serving local static files in the expresss server setup.

4. Configured development to point to ropsten testnet instead of using a local chain.

<br />
<br />
<br />
<br />





> Actually, it's gonna be hack to npm install every time you want to rebuild with changes, so if process.node.ENV == localhost then don't delete the full-build dir, just replace what is in there leaving node_modules intact. There must be a better way to do this... Let's see what Jakub says when he is around, because I am invariably wrong about these things...

Not sure how to do this tbh.