### PR TITLE
don't save images with full URL, just path is enough

### DIFF
--- a/back-end/services/dapp-image-service.js
+++ b/back-end/services/dapp-image-service.js
@@ -24,7 +24,7 @@ class DAppImageService {
 }
 
 const buildImageUrl = function (req, imageHash) {
-    return `${req.protocol}://${req.headers.host}${req.originalUrl}/image/${imageHash}`;
+    return `/metadata/image/${imageHash}`;
 }
 
 module.exports = DAppImageService;


### PR DESCRIPTION
Resolves #55 by making the backend save images by just path, not full URL.
Full URL is also bad if we'd ever want to change domains or anything like that.

Test result:
```
> db.dappsmetadatas.find({email: "ihave@autism.io"}).pretty()
{
	"_id" : ObjectId("5df20b080d472e0a6ff2a893"),
	"status" : "NEW",
	"details" : {
		"name" : "autism.io",
		"url" : "https://autism.io",
		"description" : "yep",
		"category" : "OTHER",
		"image" : "/metadata/image/QmUNhcMGY2tSYLpaXwzndYhF16enDymsGKY3KHBpxzDS1t",
		"dateAdded" : 1576143623721,
		"uploader" : "0x9b64770c9485a5188d238c305e53627a67c05d7d"
	},
	"compressedMetadata" : "0xc3d95f8a89e55768f3252b6b09bbcc76e2a1310c7a874690ddae7ee4627b7633",
	"email" : "ihave@autism.io",
	"hash" : "QmXxdTo3xg6dEfHtBxPzkgpSg1zUj7DwEdd2Fir4CEonEG",
	"__v" : 0
}
```
Request looks correct:
![dapp_image_success](https://user-images.githubusercontent.com/2212681/70703558-aa0d6000-1cd0-11ea-8d7f-8ca30ed1f32e.png)