### PR TITLE
run infura calls in parallel, not sequentially

### DIFF
--- a/src/common/blockchain/services/discover-service/discover-service.js
+++ b/src/common/blockchain/services/discover-service/discover-service.js
@@ -59,13 +59,14 @@ class DiscoverService extends BlockchainService {
       const dappsCache = JSON.parse(
         JSON.stringify(await MetadataClient.retrieveMetadataCache()),
       )
-      const dapps = []
 
-      for (let i = 0; i < contractDappsCount; i++) {
-        const dapp = await DiscoverContract.methods
-          .dapps(i)
-          .call({ from: this.sharedContext.account })
+      let asyncCalls = [...Array(contractDappsCount).keys()].map(
+        i => DiscoverContract.methods.dapps(i).call({ from: this.sharedContext.account })
+      )
+      /* using Promise.all() to run calls in parallel */
+      let dapps = await Promise.all(asyncCalls)
 
+      for (let dapp of dapps) {
         const dappMetadata = dappsCache[dapp.metadata]
         if (dappMetadata) {
           delete dappsCache[dapp.metadata]


### PR DESCRIPTION
Fixes #54 by replacing making Infura requests about Dapps sequentially with a parallel approach.

The purpose of this is to avoid these kind of load graphs:
![infura_seq_req](https://user-images.githubusercontent.com/2212681/70710977-b5688780-1ce0-11ea-9833-0d33c4c0b1a7.png)
https://www.webpagetest.org/result/191212_FQ_f0314579c239ced511cfff26214e7c8e/1/details/#waterfall_view_step1