### PR TITLE
set cache-control with max-age=60 for /metadata/all

### DIFF
--- a/back-end/controllers/dapps-metadata-controller.js
+++ b/back-end/controllers/dapps-metadata-controller.js
@@ -130,6 +130,8 @@ class DAppsMetadataController {
       dappsFormatedMetadata[metadataHash] = dappsMetadata[i]
     }
 
+    /* don't cache for longer than 60 seconds to show new dapps quicker */
+    res.set('Cache-Control', 'public, max-age=60')
     res.status(200).json(dappsFormatedMetadata)
   }
 


### PR DESCRIPTION
This should fix issues with calls to `/metadata/all` getting old cached results and not seeing new Dapps.

In addition to that I'm also adding a setting to CloudFront in https://github.com/dap-ps/infra-dapps/issues/17.