### PR TITLE
use our IPFS cluster at ipfs.status.im for uploads

### DIFF
--- a/back-end/config/index.js
+++ b/back-end/config/index.js
@@ -17,8 +17,8 @@ const config = {
   ADMIN_USER                   : env.ADMIN_USER                   || "admin",
   ADMIN_PASSWORD               : env.ADMIN_PASSWORD               || "discoverbancor",
   /* IPFS */
-  IPFS_HOST                    : env.IPFS_HOST                    || "ipfs.infura.io",
-  IPFS_PORT                    : env.IPFS_PORT                    || "5001",
+  IPFS_HOST                    : env.IPFS_HOST                    || "ipfs.status.im",
+  IPFS_PORT                    : env.IPFS_PORT                    || "443",
   IPFS_PROTOCOL                : env.IPFS_PROTOCOL                || "https",
   /* Blockchain */
   DISCOVER_CONTRACT            : env.DISCOVER_CONTRACT            || "0x02d990A1C66e4Cf00bCdD98a0196149F7DdA2065",

--- a/back-end/controllers/dapps-metadata-controller.js
+++ b/back-end/controllers/dapps-metadata-controller.js
@@ -141,7 +141,8 @@ class DAppsMetadataController {
     if (dappMetadata) {
       dappMetadata.status = DAPP_METADATA_STATUSES.APPROVED
 
-      dappMetadata.ipfsHash = await IPFSService.addContent(dappMetadata.details)
+      var json = JSON.stringify(dappMetadata.details);
+      dappMetadata.ipfsHash = await IPFSService.addContent(json)
 
       await dappMetadata.save()
 

--- a/back-end/models/dapps-metadata-model.js
+++ b/back-end/models/dapps-metadata-model.js
@@ -66,13 +66,13 @@ let DAppsMetadataSchema = new Schema({
 });
 
 DAppsMetadataSchema.pre('save', async function () {
-    const hash = await IPFSService.generateContentHash(this.details);
-    this.set({ hash: hash });
+    const hash = await IPFSService.addContent(this.details);
+    this.set({ hash });
 });
 
 DAppsMetadataSchema.statics.findByPlainMetadata = async function (metadata) {
     const hash = await IPFSService.generateContentHash(metadata);
-    return this.findOne({ hash: hash });
+    return this.findOne({ hash });
 }
 
 DAppsMetadataSchema.statics.findByBytes32Hash = async function (bytes32Hash) {

--- a/back-end/services/ipfs-service.js
+++ b/back-end/services/ipfs-service.js
@@ -17,17 +17,22 @@ class IPFSService {
         return IPFSService.instance;
     }
 
-    async addContent(content) {
-        // Todo: pin the hash. Infura does not support it.
-        const contentHash = await this.storage.add(Buffer.from(JSON.stringify(content)));
-
-        logger.info(`Content ${content} was successfully uploaded in IPFS`);
-        return contentHash[0].hash;
+    async addContent(content, filename='data.json') {
+        let data
+        if (Buffer.isBuffer(content)) {
+          data = content
+        } else if (typeof content == "object") {
+          data = Buffer.from(JSON.stringify(content));
+        } else {
+          data = Buffer.from(content);
+        }
+        const resp = await this.storage.add(data, {pin: true});
+        logger.info(`Content uploaded to IPFS: ${resp[0].hash}`);
+        return resp[0].hash;
     }
 
     async generateContentHash(content) {
-        const contentHash = await this.storage.add(Buffer.from(JSON.stringify(content)), { onlyHash: true });
-        return contentHash[0].hash;
+        return this.addContent(content);
     }
 }
 


### PR DESCRIPTION
In relation to https://github.com/status-im/infra-ipfs/issues/2 I'm switching IPFS to use our own cluster at https://ipfs.status.im/.

I'm making `generateContentHash()` just call `addContent()` because using `only-hash` on an IPFS cluster proxy API fails with:
```
only-hash is not supported when adding to cluster
```
This is already deployed to https://dev.dap.ps/ and I've tested it with some stuff like:
* https://ipfs.status.im/QmTcF6FJsmddpRHJZrP2vKWPMHHqqgfTkueGLEo5Wrz5sq
* https://ipfs.status.im/QmeXp7FR7FSCKq2TVvXuhkqXbcsatZUM49JptuJXBrJ9zB