### PR TITLE
set ipfsHash on DApp creation

### DIFF
--- a/back-end/models/dapps-metadata-model.js
+++ b/back-end/models/dapps-metadata-model.js
@@ -62,12 +62,14 @@ let DAppsMetadataSchema = new Schema({
         default: "NEW",
         enum: metadataStatuses
     },
+    /* This is used for new IPFS hash when DApp changes status */
     ipfsHash: String
 });
 
 DAppsMetadataSchema.pre('save', async function () {
     const hash = await IPFSService.addContent(this.details);
-    this.set({ hash });
+    /* We set ipfsHash so even unapproved DApps have it set */
+    this.set({ hash, ipfsHash: hash });
 });
 
 DAppsMetadataSchema.statics.findByPlainMetadata = async function (metadata) {


### PR DESCRIPTION
This solves the issue from https://github.com/status-im/infra-ipfs/issues/4 where we used to incorrectly upload DApp metadata to IPFS while quoted(lel) and not pinned(2xlel). I've fixed the IPFS hashes and set the `ipfsHash` attribute of a DApp to the new hash. We cannot change `hash` because that breaks our connection with their identity in the contract.