### PR TITLE
fix re-declaring content variable

### DIFF
--- a/back-end/models/dapps-images-model.js
+++ b/back-end/models/dapps-images-model.js
@@ -22,8 +22,8 @@ DAppsImageSchema.pre('save', async function () {
     this.set({ content, hash });
 });
 
-DAppsImageSchema.statics.findByContent = async function (content) {
-    const content = content.split('base64,')[1];
+DAppsImageSchema.statics.findByContent = async function (input) {
+    const content = input.split('base64,')[1];
     const data = Buffer.from(content, 'base64');
     const hash = await IPFSService.generateContentHash(data);
 


### PR DESCRIPTION
This fixes the backend error when uploading a Dapp:
```
[2020-02-14 09:59:30]-[INFO]-[IPFS-Service]: Content uploaded to IPFS: QmRok67sWEib5BuvFXdckoqB83EGo81MmQGz7pKzcpU3UF
SyntaxError: Identifier 'content' has already been declared
    at Function.upload (/var/app/current/services/dapp-image-service.js:12:55)
    at process._tickCallback (internal/process/next_tick.js:68:7)
Error: Identifier 'content' has already been declared
    at Function.upload (/var/app/current/services/dapp-metadata-service.js:41:13)
    at process._tickCallback (internal/process/next_tick.js:68:7)
```